### PR TITLE
Cleaning middlewares, use gorilla access restriction helper

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,22 +5,20 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/iZonex/device-control/handlers"
-	"github.com/iZonex/device-control/middleware"
-
 	"github.com/gorilla/mux"
+	"github.com/iZonex/device-control/handlers"
 )
 
 func main() {
 
 	r := mux.NewRouter()
 	fs := http.FileServer(http.Dir("./static/"))
-	r.HandleFunc("/", middleware.Chain(handlers.WifiHandler, middleware.Method("GET")))
-	r.HandleFunc("/status", middleware.Chain(handlers.MainHandler, middleware.Method("GET")))
-	r.HandleFunc("/api/status", middleware.Chain(handlers.DeviceInformationHandler, middleware.Method("GET")))
-	r.HandleFunc("/wifi", middleware.Chain(handlers.WifiHandler, middleware.Method("GET")))
+	r.HandleFunc("/", handlers.WifiHandler).Methods("GET")
+	r.HandleFunc("/status", handlers.MainHandler).Methods("GET")
+	r.HandleFunc("/api/status", handlers.DeviceInformationHandler).Methods("GET")
+	r.HandleFunc("/wifi", handlers.WifiHandler).Methods("GET")
 	r.PathPrefix("/static/").Handler(http.StripPrefix("/static/", fs))
-	r.HandleFunc("/server", middleware.Chain(handlers.ServerHandler, middleware.Method("GET")))
+	r.HandleFunc("/server", handlers.ServerHandler).Methods("GET")
 
 	http.Handle("/", r)
 	srv := &http.Server{

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -4,27 +4,6 @@ import "net/http"
 
 type Middleware func(http.HandlerFunc) http.HandlerFunc
 
-// Method ensures that url can only be requested with a specific method, else returns a 400 Bad Request
-func Method(m string) Middleware {
-
-	// Create a new Middleware
-	return func(f http.HandlerFunc) http.HandlerFunc {
-
-		// Define the http.HandlerFunc
-		return func(w http.ResponseWriter, r *http.Request) {
-
-			// Do middleware things
-			if r.Method != m {
-				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
-				return
-			}
-
-			// Call the next middleware/handler in chain
-			f(w, r)
-		}
-	}
-}
-
 func Chain(f http.HandlerFunc, middlewares ...Middleware) http.HandlerFunc {
 	for _, m := range middlewares {
 		f = m(f)


### PR DESCRIPTION
Drop handcrafted access restriction, use provided one by   🦍